### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -149,7 +149,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that libubootenv could not be built reproducibly.

This is due to the docs using absolute build paths. This was originally filed in Debian as [#939547](https://bugs.debian.org/939547).