### PR TITLE
fw_printenv: fw_printenv must fail if asked for an unset variable

### DIFF
--- a/src/fw_printenv.c
+++ b/src/fw_printenv.c
@@ -143,7 +143,11 @@ int main (int argc, char **argv) {
 			}
 		} else {
 			for (i = 0; i < argc; i++) {
-				value = libuboot_get_env(ctx, argv[i]);
+				if ((value = libuboot_get_env(ctx, argv[i])) == NULL) {
+					fprintf(stderr, "\"%s\" not defined.\n", argv[i]);
+					ret++;
+				}
+
 				if (noheader)
 					fprintf(stdout, "%s\n", value ? value : "");
 				else


### PR DESCRIPTION
The return status from fw_printenv must indicate failure if asked to
print a variable that is unset.

Signed-off-by: Mathias Thore <mathias.thore@atlascopco.com>