### PR TITLE
Dont store to device if no value changes

### DIFF
--- a/src/fw_printenv.c
+++ b/src/fw_printenv.c
@@ -151,17 +151,22 @@ int main (int argc, char **argv) {
 			}
 		}
 	} else { /* setenv branch */
+		bool ok_change = false, ok_write = false;
 		if (scriptfile)
 			libuboot_load_file(ctx, scriptfile);
 		else {
 			for (i = 0; i < argc; i += 2) {
 				if (i + 1 == argc)
-					libuboot_set_env(ctx, argv[i], NULL);
+					ok_write = (libuboot_set_env(ctx, argv[i], NULL) == 0);
 				else
-					libuboot_set_env(ctx, argv[i], argv[i+1]);
+					ok_write = (libuboot_set_env(ctx, argv[i], argv[i+1]) == 0);
+				if (ok_write)
+					ok_change = true;
 			}
 		}
-		ret = libuboot_env_store(ctx);
+
+		if (ok_change)
+			ret = libuboot_env_store(ctx);
 		if (ret)
 			fprintf(stderr, "Error storing the env\n");
 	}

--- a/src/uboot_env.c
+++ b/src/uboot_env.c
@@ -1242,8 +1242,16 @@ int libuboot_set_env(struct uboot_ctx *ctx, const char *varname, const char *val
 			if (!value) {
 				free_var_entry(envs, entry);
 			} else {
-				free(entry->value);
-				entry->value = strdup(value);
+				if (strcmp(entry->value, value) == 0) {
+#if !defined(NDEBUG)
+					fprintf(stdout, "No change to parameter, old %s, new %s\n",
+						entry->value, value);
+#endif
+					return -EAGAIN;
+				} else {
+					free(entry->value);
+					entry->value = strdup(value);
+				}
 			}
 			return 0;
 		} else {


### PR DESCRIPTION
When fw_setenv is called, it could happen that the new value is same
with the old one, in which case, we should avoid storing data to
device.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>