### PR TITLE
Fix file reading/writing when the environment is in EEPROM

### DIFF
--- a/src/uboot_env.c
+++ b/src/uboot_env.c
@@ -455,7 +455,22 @@ static int fileread(struct uboot_flash_env *dev, void *data)
 	if (ret < 0)
 		return ret;
 
-	ret = read(dev->fd, data, dev->envsize);
+	size_t remaining = dev->envsize;
+
+	while (1) {
+		ret = read(dev->fd, data, remaining);
+
+		if (ret < 0)
+			break;
+
+		remaining -= ret;
+		data += ret;
+
+		if (!remaining) {
+			ret = dev->envsize;
+			break;
+		}
+	}
 
 	return ret;
 }
@@ -653,7 +668,22 @@ static int filewrite(struct uboot_flash_env *dev, void *data)
 	if (ret < 0)
 		return ret;
 
-	ret = write(dev->fd, data, dev->envsize);
+	size_t remaining = dev->envsize;
+
+	while (1) {
+		ret = write(dev->fd, data, remaining);
+
+		if (ret < 0)
+			break;
+
+		remaining -= ret;
+		data += ret;
+
+		if (!remaining) {
+			ret = dev->envsize;
+			break;
+		}
+	}
 
 	fileprotect(dev, true);  // no error handling, keep ret from write
 


### PR DESCRIPTION
Trying to use fw_printenv/fw_setenv with
/sys/bus/i2c/devices/0-0050/eeprom always fails for me:

$ fw_printenv
Cannot read environment, using default
Cannot read default environment from file
$

The problem is that fileread() and filewrite() in src/uboot_env.c
read/write once, and callers treat it as error if they did read/write
fewer bytes than requested.

In C it is not an error if fewer bytes get read/written than requested,
the caller is supposed to retry with the remaining bytes until everything
is done or an error occurs.