### PR TITLE
fw_printenv: return non-zero status when uboot env doesn't exist

### DIFF
--- a/src/fw_printenv.c
+++ b/src/fw_printenv.c
@@ -146,6 +146,7 @@ int main (int argc, char **argv) {
 		} else {
 			for (i = 0; i < argc; i++) {
 				value = libuboot_get_env(ctx, argv[i]);
+				ret |= (value == NULL);
 				if (noheader)
 					fprintf(stdout, "%s\n", value ? value : "");
 				else


### PR DESCRIPTION
Match the behaviour of uboot fw_printenv by returning a non-zero exit
code when a specified env variable doesn't exist.