### PR TITLE
Include cstddef in the header for C++

### DIFF
--- a/src/libuboot.h
+++ b/src/libuboot.h
@@ -6,6 +6,8 @@
  */
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
 #endif
 


### PR DESCRIPTION
So C++ compiler always has access to the definition of size_t.

Signed-off-by: Oleksandr Kravchuk <open.source@oleksandr-kravchuk.com>