### PR TITLE
fw_printenv: dont hard-code configuration/environment files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(BUILD_DOC "Build documentation" ON)
 # check if Doxygen is installed
 if(BUILD_DOC)
     find_package(Doxygen)
-    if (DOXYGEN_FOUND)
+    if(DOXYGEN_FOUND)
         # set input and output files
         set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
         set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
@@ -47,7 +47,7 @@ if(BUILD_DOC)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Generating API documentation with Doxygen"
             VERBATIM )
-    else (DOXYGEN_FOUND)
+    else(DOXYGEN_FOUND)
       message("Doxygen need to be installed to generate the doxygen documentation")
-    endif (DOXYGEN_FOUND)
-endif()
+    endif(DOXYGEN_FOUND)
+endif(BUILD_DOC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ set(VERSION	"0.3.2")
 SET(SOVERSION "0")
 add_definitions(-DVERSION="${VERSION}")
 
+if(DEFAULT_CFG_FILE)
+    add_definitions(-DDEFAULT_CFG_FILE="${DEFAULT_CFG_FILE}")
+endif(DEFAULT_CFG_FILE)
+
+if(DEFAULT_ENV_FILE)
+    add_definitions(-DDEFAULT_ENV_FILE="${DEFAULT_ENV_FILE}")
+endif(DEFAULT_ENV_FILE)
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 
 #set(CMAKE_C_FLAGS_DEBUG "-g")

--- a/src/fw_printenv.c
+++ b/src/fw_printenv.c
@@ -20,6 +20,14 @@
 #define VERSION "0.1"
 #endif
 
+#ifndef DEFAULT_CFG_FILE
+#define DEFAULT_CFG_FILE "/etc/fw_env.config"
+#endif
+
+#ifndef DEFAULT_ENV_FILE
+#define DEFAULT_ENV_FILE "/etc/u-boot-initial-env"
+#endif
+
 #define PROGRAM_SET	"fw_setenv"
 
 static struct option long_options[] = {
@@ -127,7 +135,7 @@ int main (int argc, char **argv) {
 	}
 
 	if (!cfgfname)
-		cfgfname = "/etc/fw_env.config";
+		cfgfname = DEFAULT_CFG_FILE;
 
 	if ((ret = libuboot_read_config(ctx, cfgfname)) < 0) {
 		fprintf(stderr, "Configuration file wrong or corrupted\n");
@@ -135,7 +143,7 @@ int main (int argc, char **argv) {
 	}
 
 	if (!defenvfile)
-		defenvfile = "/etc/u-boot-initial-env";
+		defenvfile = DEFAULT_ENV_FILE;
 
 	if ((ret = libuboot_open(ctx)) < 0) {
 		fprintf(stderr, "Cannot read environment, using default\n");


### PR DESCRIPTION
Avoid to hard-code configuration and environment files, allow them to
be configurable during build. This is usefull when some end users want
to distinguish these files at build time rather than run time with
command parameters.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>