### PR TITLE
fw_env_config.md: fix mismatching text

### DIFF
--- a/docs/fw_env_config.md
+++ b/docs/fw_env_config.md
@@ -111,11 +111,10 @@ uboot:
     - path : /dev/mtd0
       offset : 0xA0000
       sectorsize : 0x10000
-      unlock : yes
+      disablelock : yes
     - path : /dev/mtd0
       offset : 0xB0000
       sectorsize : 0x10000
-      disable-lock : yes
 
 appvar:
   size : 0x4000
@@ -124,7 +123,7 @@ appvar:
     - path : /dev/mtd1
       offset : 0
       sectorsize : 0x10000
-      unlock : yes
+      disablelock : no
     - path : /dev/mtd1
       offset : 0x10000
       sectorsize : 0x10000

--- a/src/uboot_env.c
+++ b/src/uboot_env.c
@@ -1365,7 +1365,7 @@ int consume_event(struct parser_state *s, yaml_event_t *event)
 				s->state = STATE_NOFFSET;
 			} else if (!strcmp(value, "sectorsize")) {
 				s->state = STATE_NSECTORSIZE;
-				} else if (!strcmp(value, "disablelock")) {
+			} else if (!strcmp(value, "disablelock")) {
 				s->state = STATE_NUNLOCK;
 			} else {
 				s->error = YAML_UNEXPECTED_KEY;


### PR DESCRIPTION
There is no "unlock", "disable-lock" states supported in src/uboot_env.c, replace them with "disablelock".

Also fix an invalid indention in src/uboot_env.c.