### PR TITLE
RFC: Add range check for variables

### DIFF
--- a/src/uboot_private.h
+++ b/src/uboot_private.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <sys/queue.h>
 #include <sys/types.h>
+#include <regex.h>
 #include "libuboot.h"
 
 #define UBI_MAX_VOLUME			128
@@ -76,6 +77,19 @@ typedef enum {
 	ACCESS_ATTR_WRITE_ONCE,
 	ACCESS_ATTR_CHANGE_DEFAULT,
 } access_attribute;
+
+typedef struct {
+	int available;
+	type_attribute type;
+	union  {
+		char* re;
+		uint64_t bitmask;
+		struct {
+			int64_t min;
+			int64_t max;
+		} int_range;
+	} u;
+} range_attribute;
 
 enum flags_type {
 	FLAGS_NONE,
@@ -150,6 +164,8 @@ struct var_entry {
 	type_attribute type;
 	/** Permissions for the variable */
 	access_attribute access;
+	/** Range for the variable */
+	range_attribute	range;
 	/** Pointer to next element in the list */
 	LIST_ENTRY(var_entry) next;
 };


### PR DESCRIPTION
This is *untested* with U-Boot. I'm hope to get some feedback whether such feature is desirable or even makes sense before invensting more time in it (starting the counter-part in U-Boot). 

As a use-case I see general validation for variables to prevent system misconfiguration.

Here the commit message/usage information:

Add range check for variables using the ".flags" variable. Different types of ranges can be specified for strings, decimals and hex-values.

- For string one can specify a regular expression for valid string.
- For decimals one can specify an integer range
- For hex values one can specify a bitmask

The range is added by the '@' character after the access flags.

Example:

Environment:

.flags=foo:sw@r"aaab+",bla:dw@100-200,blub:xw@0xffff foo=aaab
bla=123
blub=0x1234

Commandline:

$ fw_setenv foo aaac
libuboot_set_env failed: -1

$ fw_setenv foo aaabbbb
$ fw_printenv
bla=123
blub=0x1234
foo=aaabbb