### PR TITLE
Mitigate -Wunused-variable

### DIFF
--- a/src/extended_config.c
+++ b/src/extended_config.c
@@ -81,7 +81,6 @@ static int consume_event(struct parser_state *s, yaml_event_t *event)
 	char *value;
 	struct uboot_flash_env *dev;
 	struct uboot_ctx *newctx;
-	int cdev;
 
 	switch (s->state) {
 	case STATE_START:
@@ -271,7 +270,7 @@ static int consume_event(struct parser_state *s, yaml_event_t *event)
 	case STATE_WRITELIST:
 		switch (event->type) {
 
-		char *varflag, *name;
+		char *varflag;
 		struct var_entry *entry;
 
 		case YAML_MAPPING_START_EVENT:

--- a/src/fw_printenv.c
+++ b/src/fw_printenv.c
@@ -86,7 +86,6 @@ int main (int argc, char **argv) {
 	bool is_setenv = false;
 	bool noheader = false;
 	bool default_used = false;
-	struct uboot_version_info *version;
 
 	/*
 	 * As old tool, there is just a tool with symbolic link

--- a/src/uboot_env.c
+++ b/src/uboot_env.c
@@ -941,7 +941,7 @@ int libuboot_read_config(struct uboot_ctx *ctx, const char *config)
 
 int libuboot_set_env(struct uboot_ctx *ctx, const char *varname, const char *value)
 {
-	struct var_entry *entry, *entryvarlist = NULL;
+	struct var_entry *entryvarlist = NULL;
 	if (strchr(varname, '='))
 		return -EINVAL;
 

--- a/src/uboot_mtd.c
+++ b/src/uboot_mtd.c
@@ -222,7 +222,6 @@ int libubootenv_ubi_update_name(struct uboot_flash_env *dev)
 	char device[DEVNAME_MAX_LENGTH];
 	char volume[VOLNAME_MAX_LENGTH];
 	int dev_id, vol_id, fd, ret = -EBADF;
-	struct stat st;
 	char *sep;
 
 	if (!strncmp(dev->devname, DEVICE_MTD_NAME, strlen(DEVICE_MTD_NAME)))


### PR DESCRIPTION
Low hanging fruits of reducing compiler warnings.  Code hygiene.